### PR TITLE
Fix: railtypetable

### DIFF
--- a/src/RAILTYPETABLE.pnml
+++ b/src/RAILTYPETABLE.pnml
@@ -1,9 +1,9 @@
 railtypetable 
 	{
-		"RAIL",
-		ELEC: [ELRL],
-		ELRL: [ELRL],
+		RAIL: [SAAN, RAIL],
+		ELEC: [SAAE, ELRL],
+		ELRL: [SAAE, ELRL],
 		AC15: [SAAa, SAAA, SAAE, ELRL],
-		MTRO: ["3RDR", ELRL]
+		MTRO: [MTRO, SAA3, "3RDR", ELRL]
 	}
 	


### PR DESCRIPTION
The old setup wasn't quite as expected by the standard this mostly didn't mater but caused issues when loaded with xUSSR Rails this should fix that while also making sure that MTRO is actually being used if avaliable